### PR TITLE
Bugfix: Core Functionality

### DIFF
--- a/src/app/code/community/Bugsnag/Notifier/Model/Observer.php
+++ b/src/app/code/community/Bugsnag/Notifier/Model/Observer.php
@@ -15,7 +15,7 @@ class Bugsnag_Notifier_Model_Observer
     private $notifySeverities;
     private $filterFields;
 
-    public static function fireTestEvent($apiKey) {
+    public function fireTestEvent($apiKey) {
         if (strlen($apiKey) != 32) {
             throw new Exception("Invalid length of the API key");
         }
@@ -38,8 +38,8 @@ class Bugsnag_Notifier_Model_Observer
         }
 
         $this->apiKey = Mage::getStoreConfig("dev/Bugsnag_Notifier/apiKey");
-        $this->notifySeverities = Mage::getStoreConfig("dev/Bugsnag_Notifier/severites");
-        $this->filterFields = Mage::getStoreConfig("dev/Bugsnag_Notifier/filterFiels");
+        $this->notifySeverities = Mage::getStoreConfig("dev/Bugsnag_Notifier/severities");
+        $this->filterFields = Mage::getStoreConfig("dev/Bugsnag_Notifier/filterFields");
 
         // Activate the bugsnag client
         if (!empty($this->apiKey)) {

--- a/src/app/code/community/Bugsnag/Notifier/controllers/Adminhtml/BugsnagController.php
+++ b/src/app/code/community/Bugsnag/Notifier/controllers/Adminhtml/BugsnagController.php
@@ -4,7 +4,8 @@ class Bugsnag_Notifier_Adminhtml_BugsnagController extends Mage_Adminhtml_Contro
 {
     public function checkAction()
     {
-        Bugsnag_Notifier_Model_Observer::fireTestEvent($_POST["apiKey"]);
+        $obs = Mage::getModel('Bugsnag_Notifier/Observer');
+        $obs->fireTestEvent($_POST["apiKey"]);
         $successCode = 1;
         Mage::app()->getResponse()->setBody($successCode);
     }

--- a/src/app/code/community/Bugsnag/Notifier/etc/config.xml
+++ b/src/app/code/community/Bugsnag/Notifier/etc/config.xml
@@ -8,7 +8,7 @@
   <global>
     <models>
       <Bugsnag_Notifier>
-        <class>Bugsang_Notifier_Model</class>
+        <class>Bugsnag_Notifier_Model</class>
       </Bugsnag_Notifier>
     </models>
     <events>
@@ -28,7 +28,7 @@
       <adminhtml>
         <args>
           <modules>
-            <Bungsnag_Notifier after="Mage_Adminhtml">Bugsnag_Notifier</Bungsnag_Notifier>
+            <Bugsnag_Notifier after="Mage_Adminhtml">Bugsnag_Notifier</Bugsnag_Notifier>
           </modules>
         </args>
       </adminhtml>


### PR DESCRIPTION
Resolves #2 .
# Fixed
- Many typographical errors. These typos prevented the extension from reporting most events!
# How to test this PR
1. Install the extension and set the reporting level to "Crashes, errors, warnings & info messages".
2. Expect for Bugsnag events to be reported! Something like
   
   ``` php
   trigger_error('This is a notice', E_USER_NOTICE);
   ```
   
   should do the trick.
