### PR TITLE
Update Error.php

### DIFF
--- a/src/lib/bugsnag-php/Error.php
+++ b/src/lib/bugsnag-php/Error.php
@@ -212,7 +212,7 @@ class Bugsnag_Error
                     // Check if this key should be filtered
                     $shouldFilter = false;
                     foreach ($this->config->filters as $filter) {
-                        if (strpos($key, $filter) !== false) {
+                        if (!empty($filter) && strpos($key, $filter) !== false) {
                             $shouldFilter = true;
                             break;
                         }


### PR DESCRIPTION
Fix following error:

PHP Fatal error:  Uncaught Exception: Warning: strpos(): Empty needle  in .modman/bugsnag-magento/src/lib/bugsnag-php/Error.php on line 218